### PR TITLE
Add hashrate distribution chart and remove bottom nav

### DIFF
--- a/src/components/pages/ChartDetails.tsx
+++ b/src/components/pages/ChartDetails.tsx
@@ -11,9 +11,11 @@ export const ChartDetails = () => (
     <CustomView style={styles.container}>
       <CustomText style={styles.title}>Mempool Transaction Count</CustomText>
       <CustomText>
-        In blockchain terminology, a mempool is a waiting area for the transactions that haven't
-        been added to a block and are still unconfirmed. This is how a Blockchain node deals with
-        transactions that have not yet been included in a block.
+        The mempool is where all valid transactions wait to be confirmed by the Bitcoin network. A
+        high number of transactions in the mempool indicates a congested traffic which will result
+        in longer average confirmation time and higher priority fees. The mempool count metric tells
+        how many transactions are causing the congestion whereas the Mempool Size (Bytes) chart is a
+        better metric to estimate how long the congestion will last.
       </CustomText>
     </CustomView>
     <CustomView style={styles.container}>
@@ -25,7 +27,19 @@ export const ChartDetails = () => (
         Bitcoin chart displays how many of them have already been found.
       </CustomText>
     </CustomView>
+    <CustomView style={styles.container}>
+      <CustomText style={styles.title}>Hashrate Distribution</CustomText>
+      <CustomText>
+        A mining pool is a group of miners who share their computing power over a network and get
+        rewarded based on the amount of power each contributes as opposed to whether or not the pool
+        finds a block. Mining pools help make revenue for miners more predictable. Huge drops in
+        weekly numbers could highlight that some mining pools are either being turned off or they
+        have decided to mine other currencies. If a mining pool were to control more than half of
+        the total hashrate, it could (while unlikely) lead to a 51% attack on the network.
+      </CustomText>
+    </CustomView>
 
+    <CustomText>Source: Blockchain.com</CustomText>
     {/* Use a light status bar on iOS to account for the black space above the modal */}
     <StatusBar style={Platform.OS === 'ios' ? 'light' : 'auto'} />
   </CustomView>

--- a/src/components/pages/CryptoDataScreen.tsx
+++ b/src/components/pages/CryptoDataScreen.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react'
-import { Dimensions, ScrollView, Text } from 'react-native'
-import { ContributionGraph, LineChart } from 'react-native-chart-kit'
+import { Dimensions, ScrollView, Text, View } from 'react-native'
+import { ContributionGraph, LineChart, PieChart } from 'react-native-chart-kit'
 import { AbstractChartConfig } from 'react-native-chart-kit/dist/AbstractChart'
 
-import { getMarketPrice, getMempoolCount } from 'utils/api/get'
+import { getHashRateDistribution, getMarketPrice, getMempoolCount } from 'utils/api/get'
 import { formatUnixTimestamp, getAvgMempoolCount } from 'utils/data/mempool'
 
 const Y_AXIS_INCREMENT = 5000
@@ -39,10 +39,10 @@ export const CryptoDataScreen = () => {
 
   const [marketPriceGraphLabels, setMarketPriceGraphLabels] = useState<string[]>([])
   const [marketPriceGraphData, setMarketPriceGraphData] = useState<number[]>([])
-
   const [contributionGraphData, setContributionGraphData] = useState<
     { date: string; count: number }[]
   >([])
+  const [pieChartData, setPieChartData] = useState<Record<string, any>[]>([])
 
   const getLabels = (
     marketPriceData: {
@@ -51,10 +51,8 @@ export const CryptoDataScreen = () => {
     }[],
   ) => {
     const numLabels = 6
-
     const numDataPoints = marketPriceData.length
     const spaceBetweenLabels = Math.floor(numDataPoints / numLabels)
-
     const labels = [marketPriceData[0]]
 
     while (labels.length < numLabels) {
@@ -67,9 +65,7 @@ export const CryptoDataScreen = () => {
   useEffect(() => {
     const fetchData = async () => {
       const marketPriceData = await getMarketPrice()
-
       const simplifiedPriceData = marketPriceData.filter((value, index) => index % 5 === 0)
-
       setMarketPriceGraphLabels(getLabels(simplifiedPriceData))
       setMarketPriceGraphData(simplifiedPriceData.map((value) => value.y))
     }
@@ -81,7 +77,23 @@ export const CryptoDataScreen = () => {
       const mempoolCount = await getMempoolCount()
       const data = getAvgMempoolCount(mempoolCount)
       setContributionGraphData(data)
-      console.log(data[data.length - 1])
+    }
+    fetchData()
+  }, [])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const hashrateDistribution = await getHashRateDistribution()
+      const colors = ['#BFFFF0', '#F0FFC2', '#FFE4C0', '#FFBBBB', '#C1F4C5', '#65C18C', '#FF7BA9']
+      const formattedHashrateData = Object.entries(hashrateDistribution).map(([key, value], i) => {
+        return {
+          name: key,
+          blocksMined: value,
+          color: colors[i],
+          legendFontColor: '#405979',
+        }
+      })
+      setPieChartData(formattedHashrateData)
     }
     fetchData()
   }, [])
@@ -136,6 +148,23 @@ export const CryptoDataScreen = () => {
           style={graphStyle}
           tooltipDataAttrs={() => ({})}
         />
+        <Text style={labelStyle}>Hashrate Distribution by Pool</Text>
+        <Text style={{ ...labelStyle, marginVertical: 0, fontSize: 12 }}>
+          (Blocks mined last 24 hours)
+        </Text>
+        <PieChart
+          data={pieChartData}
+          width={width}
+          height={220}
+          chartConfig={chartConfig}
+          accessor='blocksMined'
+          backgroundColor={'transparent'}
+          paddingLeft={'15'}
+          center={[10, 10]}
+          absolute
+        />
+        {/* Extra space for easier scrolling */}
+        <View style={{ height: 100 }} />
       </ScrollView>
     </>
   )

--- a/src/components/pages/CryptoDataScreen.tsx
+++ b/src/components/pages/CryptoDataScreen.tsx
@@ -150,7 +150,7 @@ export const CryptoDataScreen = () => {
         />
         <Text style={labelStyle}>Hashrate Distribution by Pool</Text>
         <Text style={{ ...labelStyle, marginVertical: 0, fontSize: 12 }}>
-          (Blocks mined last 24 hours)
+          (Blocks mined last 7 days)
         </Text>
         <PieChart
           data={pieChartData}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -41,6 +41,7 @@ const BottomTabNavigator = () => {
   return (
     <BottomTab.Navigator
       initialRouteName='CryptoData'
+      tabBar={() => <></>}
       screenOptions={{
         tabBarStyle: { backgroundColor: theme.colors.header },
         tabBarActiveTintColor: theme.colors.primary,

--- a/src/utils/api/get.ts
+++ b/src/utils/api/get.ts
@@ -23,3 +23,13 @@ export const getMarketPrice = async (): Promise<{ x: number; y: number }[]> => {
     return []
   }
 }
+
+export const getHashRateDistribution = async (): Promise<Record<string, number>> => {
+  try {
+    const response = await axios.get('https://api.blockchain.info/pools?timespan=1week')
+    return response?.data
+  } catch (e) {
+    console.log('Error fetching: ', e)
+    return {}
+  }
+}


### PR DESCRIPTION
##### Description: #####
Adds additional (pie) chart for hashrate distribution for largest mining pools (blocks mined last 24 hours). Also removes bottom navigation tab without removing the "Info" icon of the outer screen for chart details.

##### Screenshots: #####
<img width="370" alt="image" src="https://user-images.githubusercontent.com/8021136/167932786-5933c582-e360-4e6f-9613-67dcd001fca7.png">
